### PR TITLE
Add automatic builds for releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,7 +36,7 @@ jobs:
         path: ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}
             
     - name: Create release archive
-      run: 7z a ClinArrivals-${{github.event.release.tag_name}}-win.zip ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}\*
+      run: 7z a ClinicArrivals-${{github.event.release.tag_name}}-win.zip ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}\*
                 
     - name: Upload archive to release
       uses: actions/upload-release-asset@v1.0.1
@@ -44,6 +44,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_name: ClinArrivals-${{github.event.release.tag_name}}-win.zip
-        asset_path: ClinArrivals-${{github.event.release.tag_name}}-win.zip
+        asset_name: ClinicArrivals-${{github.event.release.tag_name}}-win.zip
+        asset_path: ClinicArrivals-${{github.event.release.tag_name}}-win.zip
         asset_content_type: application/zip

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,10 +35,10 @@ jobs:
         name: ClinicArrivals
         path: ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}
             
-    - name: Create archive
+    - name: Create release archive
       run: 7z a ClinArrivals-${{github.event.release.tag_name}}-win.zip ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}\*
                 
-    - name: Upload to release
+    - name: Upload archive to release
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,20 +36,14 @@ jobs:
         path: ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}
             
     - name: Create archive
-      run: 7z a ClinArrivals-${{github.event.release.tag_name}}-win86.zip ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}\*
+      run: 7z a ClinArrivals-${{github.event.release.tag_name}}-win.zip ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}\*
                 
     - name: Upload to release
       uses: actions/upload-release-asset@v1.0.1
-      env: { GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}" }
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_name: ClinArrivals-${{github.event.release.tag_name}}-win86.zip
-        asset_path: ClinArrivals-${{github.event.release.tag_name}}-win86.zip
+        asset_name: ClinArrivals-${{github.event.release.tag_name}}-win.zip
+        asset_path: ClinArrivals-${{github.event.release.tag_name}}-win.zip
         asset_content_type: application/zip
-
-#     - name: Upload to release
-#       uses: JasonEtco/upload-to-release@master
-#       with:
-#         args: ClinArrivals-$(git describe --tags)-win86.zip
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,55 @@
+name: Publish release
+
+on:
+  release:
+    types: created      
+  
+jobs:
+  publish-clinicarrivals:
+    runs-on: windows-latest
+    env:
+      buildtype: Release
+     
+    steps:
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.4.0
+    
+    - name: Setup nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+    
+    - name: Setup msbuild.exe
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Checkout source code
+      uses: actions/checkout@v2.0.0
+  
+    - name: Restore packages
+      run: nuget restore
+    
+    - name: Build ClinicArrivals
+      run: msbuild /p:Configuration=${{env.buildtype}} -maxcpucount:2 ClinicArrivals.sln
+    
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: ClinicArrivals
+        path: ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}
+            
+    - name: Create archive
+      run: 7z a ClinArrivals-${{github.event.release.tag_name}}-win86.zip ${{runner.workspace}}\ClinicArrivals\ClinicArrivals\bin\${{env.buildtype}}\*
+                
+    - name: Upload to release
+      uses: actions/upload-release-asset@v1.0.1
+      env: { GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}" }
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_name: ClinArrivals-${{github.event.release.tag_name}}-win86.zip
+        asset_path: ClinArrivals-${{github.event.release.tag_name}}-win86.zip
+        asset_content_type: application/zip
+
+#     - name: Upload to release
+#       uses: JasonEtco/upload-to-release@master
+#       with:
+#         args: ClinArrivals-$(git describe --tags)-win86.zip
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/documentation/Documentation.md
+++ b/documentation/Documentation.md
@@ -23,6 +23,9 @@ Documentation:
 * [Getting Support](Support.md)
 * [Technical Specifications for the PMS integration](FHIRDocumentation.md)
 
+Developer documentation:
+
+* [Making a new release](Releasing.md)
 
 ## Patient-focused Documentation
 

--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -1,0 +1,9 @@
+# Making a new ClinicArrivals release
+
+Target audience: ClinicArrivals developers.
+
+1. Create a release using the standard Github interface ([instructions](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository)).
+2. Wait 2-3 mins for the [release publication](https://github.com/grahamegrieve/ClinicArrivals/actions?query=workflow%3A%22Publish+release%22) workflow to run.
+3. When the workflow is done, refresh the release page and verity that the new release zip is now attached.
+
+The release is now ready to be published with the world.

--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -4,6 +4,6 @@ Target audience: ClinicArrivals developers.
 
 1. Create a release using the standard Github interface ([instructions](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository)).
 2. Wait 2-3 mins for the [release publication](https://github.com/grahamegrieve/ClinicArrivals/actions?query=workflow%3A%22Publish+release%22) workflow to run.
-3. When the workflow is done, refresh the release page and verity that the new release zip is now attached.
+3. When the workflow is done, refresh the release page and verify that the new release zip is now attached.
 
-The release is now ready to be published with the world.
+The release is now ready to be published to the world.


### PR DESCRIPTION
This job will automatically build ClinicArrivals in release mode and attach it to the release you make in https://github.com/grahamegrieve/ClinicArrivals/releases.

See [the docs](https://github.com/grahamegrieve/ClinicArrivals/blob/71d7cdb011810258ca747409cda225bf195eae46/documentation/Releasing.md) on how it works