### PR TITLE
Update documentation for new release version syntax

### DIFF
--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -2,7 +2,7 @@
 
 Target audience: ClinicArrivals developers.
 
-1. Create a release using the standard Github interface ([instructions](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository)). For the version, use [SemVer 1.0.0](https://semver.org/spec/v1.0.0.html) (2.0.0 not supported).
+1. Create a release using the standard Github interface ([instructions](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository)). Use the `v#.#.#` syntax for the version.
 2. Wait 2-3 mins for the [release publication](https://github.com/grahamegrieve/ClinicArrivals/actions?query=workflow%3A%22Publish+release%22) workflow to run.
 3. When the workflow is done, refresh the release page and verify that the new release zip is now attached.
 


### PR DESCRIPTION
Per https://github.com/grahamegrieve/ClinicArrivals/pull/36 we now use `v#.#.#`.