### PR TITLE
Auto convert line endings for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This'll (in theory) ensure Git auto-convert line endings to Windows ones when downloading and back to Unix when uploading.

Background:
https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
https://stackoverflow.com/questions/10418975/how-to-change-line-ending-settings