### PR TITLE
Give a reason for quitting right away

### DIFF
--- a/ClinicArrivals/App.xaml.cs
+++ b/ClinicArrivals/App.xaml.cs
@@ -63,6 +63,7 @@ namespace ClinicArrivals
 
                 // Terminate this process and gives the underlying operating 
                 // system the specified exit code.
+                Console.WriteLine("Another instance is already running - quitting.");
                 Environment.Exit(-2);
             }
         }


### PR DESCRIPTION
The semaphore broke and thought an instance of the application was already running - when it wasn't. It was super unclear as to why the application was exiting right away instead of launching.

The whole file seems changed because it was a soup of unix and windows lineendings in one - this is a one-time pain to normalise it. Sorry!